### PR TITLE
move tape inside devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/miguelmota/Navigator.sendBeacon/issues"
   },
   "homepage": "https://github.com/miguelmota/Navigator.sendBeacon",
-  "dependencies": {
+  "devDependencies": {
     "tape": "^3.0.3"
   }
 }


### PR DESCRIPTION
When npm installed under `NODE_ENV=production`, it won't install the `tape` dependency unnecessarily . The intent of the tape dependency here becomes clearer as well.
