### PR TITLE
Remove global scope access

### DIFF
--- a/sendbeacon.js
+++ b/sendbeacon.js
@@ -17,10 +17,6 @@
     return true;
   }
 
-  if (!('sendBeacon' in navigator)) {
-    navigator.sendBeacon = sendBeacon;
-  }
-
   if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports) {
       exports = module.exports = sendBeacon;
@@ -30,5 +26,7 @@
     define([], function() {
       return sendBeacon;
     });
+  } else if ('navigator' in root && 'sendBeacon' in root.navigator) {
+    root.navigator.sendBeacon = sendBeacon;
   }
 })(this);

--- a/sendbeacon.js
+++ b/sendbeacon.js
@@ -26,7 +26,7 @@
     define([], function() {
       return sendBeacon;
     });
-  } else if ('navigator' in root && 'sendBeacon' in root.navigator) {
+  } else if ('navigator' in root && !('sendBeacon' in root.navigator)) {
     root.navigator.sendBeacon = sendBeacon;
   }
 })(this);


### PR DESCRIPTION
I want to include this polyfill in polyfill.io.  It's good practice for polyfills to use `this` for the global reference and attach things to it rather than implicitly reading globals, so we'd very much appreciate this change in order to be happier having the polyfill in our service.  Another good effect of this change is that in CommonJS and AMD environments, you will no longer leak the global.
