### PR TITLE
fix: so that sync will not always be false

### DIFF
--- a/sendbeacon.js
+++ b/sendbeacon.js
@@ -12,7 +12,7 @@ function polyfill() {
 };
 
 function sendBeacon(url, data) {
-  const event = this.event && this.event.type;
+  const event = this.event && this.event.type ? this.event.type : this.event;
   const sync = event === 'unload' || event === 'beforeunload';
 
   const xhr = ('XMLHttpRequest' in this) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');


### PR DESCRIPTION
the old state makes sync always false because the value for event will always be true/false not 'unload' or 'beforeunload'