### PR TITLE
Revert "fix: so that sync will not always be false"

### DIFF
--- a/sendbeacon.js
+++ b/sendbeacon.js
@@ -11,7 +11,7 @@ function polyfill() {
 };
 
 function sendBeacon(url, data) {
-  const event = this.event && this.event.type ? this.event.type : this.event;
+  const event = this.event && this.event.type;
   const sync = event === 'unload' || event === 'beforeunload';
 
   const xhr = ('XMLHttpRequest' in this) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');


### PR DESCRIPTION
Reverts miguelmota/Navigator.sendBeacon#11

@miguelmota, see explanation [here](https://github.com/miguelmota/Navigator.sendBeacon/pull/11#issuecomment-426893966). Even though you gave me the rights I would still like for you to see this before we merge.