### PR TITLE
Ignore example from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Convert line endings to LF (Line Feed)
 * text=auto
+example/* linguist-documentation


### PR DESCRIPTION
Ignoring `example/` directory from language stats: https://github.com/github/linguist#documentation